### PR TITLE
Add clicker support

### DIFF
--- a/src/components/Controls.astro
+++ b/src/components/Controls.astro
@@ -21,10 +21,10 @@ const { href } = Astro.props;
 	document.head.appendChild(prefetchLink)
 
 	window.addEventListener('keydown', e => {
-		if (e.key === 'ArrowRight') {
+		if (e.key === 'ArrowRight' || e.key === 'PageDown') {
 			window.location = `/${href}`
 		}
-		if (e.key === 'ArrowLeft') {
+		if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
 			if (document.referrer) {
 				history.back()
 				e.preventDefault()


### PR DESCRIPTION
[Slide clickers](https://www.amazon.com/gp/product/B075NRXJHP) often just act as keyboards with only `pageDown` and `pageUp` as their primary buttons.
We can listen to those keys to add support for clickers without changing much else.