### PR TITLE
[feat] use @view-transition

### DIFF
--- a/src/layouts/Slide.astro
+++ b/src/layouts/Slide.astro
@@ -22,7 +22,6 @@ const nextSlide = slides.at(currentSlideIndex + 1) ?? slides.at(0);;
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="view-transition" content="same-origin" />
 		<title>{title}</title>
 	</head>
 	<body>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -9,6 +9,10 @@
 @import "transitions.css";
 @import "utilities.css";
 
+@view-transition {
+  navigation: auto;
+}
+
 :root {
 	--brand: color(display-p3 0 1 .75);
 	--gray-chroma: .01;


### PR DESCRIPTION
Hi Adam,

Thanks so much for the repo. As I was watching your talk from Smashing Conf last year, I realised that with the new MPA view transition proposal, the meta tag is deprecated and we should use `@view-transition` instead. I've made this PR to update the code accordingly.

If you have time, could you please update the demo site from Smashing Conf as well (https://smashing-transitions.netlify.app/)? The view transition has stopped working there, and I believe it is your private repo.

Thanks again!

### Before

https://github.com/argyleink/morphull/assets/6767322/310420aa-6808-419d-a8d4-6ae10a005aee

### After

https://github.com/argyleink/morphull/assets/6767322/4df83be2-b640-4997-ab8c-93da74f36b93

[talk]: https://www.youtube.com/watch?v=P6Mk03isfZ8